### PR TITLE
Don't do unnecessary git pulls.

### DIFF
--- a/cos-nvidia-gpu-installer/Dockerfile
+++ b/cos-nvidia-gpu-installer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get -qq update
 RUN apt-get install -qq pciutils gcc g++ git make dpkg-dev bc module-init-tools curl
 
 RUN mkdir /lakitu-kernel
-RUN git clone https://chromium.googlesource.com/chromiumos/third_party/kernel /lakitu-kernel
+RUN git clone --no-checkout https://chromium.googlesource.com/chromiumos/third_party/kernel /lakitu-kernel
 
 ADD installer.sh /usr/bin/nvidia-installer.sh
 RUN chmod a+x /usr/bin/nvidia-installer.sh

--- a/cos-nvidia-gpu-installer/installer.sh
+++ b/cos-nvidia-gpu-installer/installer.sh
@@ -69,11 +69,13 @@ check_nvidia_device() {
 prepare_kernel_source() {
     # Checkout the correct tag.
     pushd "${KERNEL_SRC_DIR}"
-    until git pull origin
-    do
-        echo "Pulling Origin failed for Lakitu kernel source git repo. Retrying after 5 seconds" && sleep 5
-    done
-    git checkout ${LAKITU_KERNEL_SHA1}
+    if ! git checkout ${LAKITU_KERNEL_SHA1}; then
+      until git fetch origin
+      do
+        echo "Fetching origin failed for Lakitu kernel source git repo. Retrying after 5 seconds" && sleep 5
+      done
+      git checkout ${LAKITU_KERNEL_SHA1}
+    fi
 
     # Prepare kernel configu and source for modules.
     echo "Preparing kernel sources ..."

--- a/cos-nvidia-gpu-installer/installer.sh
+++ b/cos-nvidia-gpu-installer/installer.sh
@@ -177,7 +177,7 @@ exit_if_install_not_needed() {
 
 restart_kubelet() {
     if [ "${DEVICE_PLUGIN_ENABLED}" == "true" ]; then
-    	echo "Device plugin enabled. Skip restarting kubelet"
+        echo "Device plugin enabled. Skip restarting kubelet"
     else
         echo "Sending SIGTERM to kubelet"
         if pidof kubelet &> /dev/null; then


### PR DESCRIPTION
- Use `git fetch` instead of `git pull`. We don't need the `HEAD` checked out.
- Try `git checkout` before fetching for new objects. This will avoid fetching in cases where the needed sha is already present in the local repo.
- Don't checkout anything initially.