### PR TITLE
Download COS kernel archive at specified commit

### DIFF
--- a/cos-nvidia-gpu-installer/Dockerfile
+++ b/cos-nvidia-gpu-installer/Dockerfile
@@ -20,8 +20,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get -qq update
 RUN apt-get install -qq pciutils gcc g++ git make dpkg-dev bc module-init-tools curl
 
-RUN mkdir /lakitu-kernel
-RUN git clone --no-checkout https://chromium.googlesource.com/chromiumos/third_party/kernel /lakitu-kernel
+RUN mkdir -p /lakitu-kernel
 
 ADD installer.sh /usr/bin/nvidia-installer.sh
 RUN chmod a+x /usr/bin/nvidia-installer.sh

--- a/cos-nvidia-gpu-installer/installer.sh
+++ b/cos-nvidia-gpu-installer/installer.sh
@@ -69,13 +69,13 @@ check_nvidia_device() {
 prepare_kernel_source() {
     # Checkout the correct tag.
     pushd "${KERNEL_SRC_DIR}"
-    if ! git checkout ${LAKITU_KERNEL_SHA1}; then
-      until git fetch origin
-      do
-        echo "Fetching origin failed for Lakitu kernel source git repo. Retrying after 5 seconds" && sleep 5
-      done
-      git checkout ${LAKITU_KERNEL_SHA1}
-    fi
+    local -r download_url = "https://chromium.googlesource.com/chromiumos/third_party/kernel/+archive/${LAKITU_KERNEL_SHA1}.tar.gz"
+    local -r archive_filename = "cos-kernel.tar.gz"
+    until curl -sS "${download_url}" -o "${archive_filename}"
+    do
+      echo "Downloading COS kernel sources failed. Retrying after 5 seconds" && sleep 5
+    done
+    tar xf "${archive_filename}"
 
     # Prepare kernel configu and source for modules.
     echo "Preparing kernel sources ..."


### PR DESCRIPTION
Instead of `git pull`ing the sources this PR utilizes gitiles' feature
to download the source tarball at the specified commit.  This also
removes `git clone` from the Dockerfile.